### PR TITLE
Padding FIX

### DIFF
--- a/styles/title.tss
+++ b/styles/title.tss
@@ -2,5 +2,8 @@
 	width: Ti.UI.SIZE,
 	height: Ti.UI.SIZE,
 	
+	left:0,
+	right:0,
+	
 	touchEnabled: false
 }


### PR DESCRIPTION
It seems tha Titanium has some kind of weird rendering in horizontal layout mode. The labels with width set to "Ti.UI.SIZE" do not attach to each other but there is a small margin.

You can see this by adding a backgroundColor property to each label (Icon, Title) and innerView so you see better how this is laid out and why this fixes the problem.
