### PR TITLE
Extend defaultStyle for activeStyle

### DIFF
--- a/controllers/widget.js
+++ b/controllers/widget.js
@@ -65,7 +65,8 @@ function applyProperties(properties) {
         }
 
         if (_properties.activeStyle) {
-            _properties.defaultStyle = _.pick(_properties, _.keys(_properties.activeStyle));
+            _properties.defaultStyle = _.clone(_properties);
+            _properties.activeStyle = _.extend({}, _properties, _properties.activeStyle);
         }
     }
 


### PR DESCRIPTION
There is a bug with the defaultStyle not getting all the style elements.
This is noticed when you are working with the `font` object inside activeStyle in combination with icons.

Example:

``` javascript
Styles.set('ah-no-style', {
    font: {
        fontWeight: 'normal',
        fontSize: '15dp'
    },
    activeStyle: {
        color: '#FF0000'
    }
});
```

Without this fix the icon activeStyle properties (https://github.com/FokkeZB/nl.fokkezb.button/blob/master/controllers/icon.js#L95) would be set to:

``` javascript
{ 
    color: '#FF0000', 
    font: {
        fontFamily: 'FontAwesome'
    }
}
```

But you want it to be:

``` javascript
{ 
    color: '#FF0000', 
    font: {
        fontWeight: 'normal',
        fontSize: '15dp',
        fontFamily: 'FontAwesome'
    }
}
```

Now, I'm sure there is a reason you are using _.pick so maybe this isn't the most efficient fix. But this works for us for now. Let me know how to do it more cleanly, if needed.
