### PR TITLE
Added support for blank title

### DIFF
--- a/controllers/title.js
+++ b/controllers/title.js
@@ -7,12 +7,12 @@ if (arguments[0]) {
 function applyProperties(properties) {
 	var apply = {};
 
-	if (properties.title) {
+	if (properties.title !== undefined) {
 		apply.text = properties.title;
 		titleid = null;
 
-	} else if (properties.titleid) {
-		apply.text = L(properties.titleid);
+	} else if (properties.titleid !== undefined) {
+		apply.text = properties.titleid ? L(properties.titleid) : '';
 		titleid = properties.titleid;
 	}
 	

--- a/controllers/widget.js
+++ b/controllers/widget.js
@@ -80,7 +80,7 @@ function applyProperties(properties) {
             $.inner.add(_icon.getView());
         }
 
-        if (_properties.title || _properties.titleid) {
+        if (_properties.title !== undefined || _properties.titleid !== undefined) {
             _title = Widget.createController("title", _properties);
             $.inner.add(_title.getView());
         }


### PR DESCRIPTION
Hi, i wanted to add support for adding and removing the title after the widget creation, but then i encountered issue #19 were i've seen you left that out on purpose. So i decided to leave a possible solution for people who just want to remove/add the title (without actualy removing it), they just need to initialize the widget with a `title: ''`

Btw, love your repositories, they helped me alot.
