### PR TITLE
Some minor but effective improvements

### DIFF
--- a/controllers/widget.js
+++ b/controllers/widget.js
@@ -45,7 +45,7 @@ function applyProperties(properties) {
         _.defaults(_properties, Styles.get(_properties.style));
     }
 
-    if (properties.enabled === false) {
+    if (properties.enabled === false || properties.enabled === "false") {
         $.outer.touchEnabled = false;
 
         if (_properties.disabledStyle) {
@@ -54,8 +54,7 @@ function applyProperties(properties) {
         }
 
     } else {
-
-        if (properties.enabled === true) {
+        if (properties.enabled === true || properties.enabled === "true") {
             $.outer.touchEnabled = true;
 
             if (_properties.enabledStyle) {
@@ -285,13 +284,14 @@ function _onTouchend(e) {
         _applyOuterProperties(_properties.defaultStyle);
         _applyInnerProperties(_properties.defaultStyle);
     }
+}
 
-    if (e.type === 'touchend') {
-        $.trigger('click', {
-            type: "click",
-            source: $
-        });
-    }
+function _onClick(e) {
+	var event = {
+		type: 'click',
+		source: $
+	};
+	$.fireEvent('click', event);	
 }
 
 /*** EXPORTS ***/

--- a/views/widget.xml
+++ b/views/widget.xml
@@ -1,5 +1,5 @@
 <Alloy>
-	<View id="outer" onTouchstart="_onTouchstart" onTouchcancel="_onTouchend" onTouchend="_onTouchend">
+	<View id="outer" onTouchstart="_onTouchstart" onTouchcancel="_onTouchend" onTouchend="_onTouchend" onClick="_onClick">
 		<View id="inner" />
 	</View>
 </Alloy>


### PR DESCRIPTION
If you use an 'enabled' field in your xml file it is passed as a string, thus properties.enabled === true/false fails. Also comparing to string form prevents this issue.

I found onClick to work better as its own event. In fact it was not even working for me because $.trigger would fail, not sure why. 

Thanks for this widget, it saved our butts from the limited abilities of the default Buttons. They don't even have disabledColor in android!